### PR TITLE
Update 02 - DB Loader.sql

### DIFF
--- a/Scripts/SqlGenScript/02 - DB Loader.sql
+++ b/Scripts/SqlGenScript/02 - DB Loader.sql
@@ -5,6 +5,8 @@
 -- Create database before running the script
 USE [#DATABASE_NAME#]
 GO
+SET LANGUAGE US_ENGLISH
+GO
 
 -- 
 --  PARAMETERS


### PR DESCRIPTION
Bulk load doesn't work when the date format was different due to language settings (e.g. in japan : yyyy/MM/dd )